### PR TITLE
Added support to gather ConfigMgr Client GUID

### DIFF
--- a/Models/ClientHealthContext.cs
+++ b/Models/ClientHealthContext.cs
@@ -159,6 +159,10 @@ namespace ConfigMgrClientHealthWebservice.Models
                     .IsUnicode(false);
 
                 entity.Property(e => e.RefreshComplianceState).HasColumnType("datetime");
+
+                entity.Property(e => e.CMClientGUID)
+                    .HasMaxLength(41)
+                    .IsUnicode(false);
             });
         }
     }

--- a/Models/Clients.cs
+++ b/Models/Clients.cs
@@ -44,5 +44,6 @@ namespace ConfigMgrClientHealthWebservice.Models
         public int? PatchLevel { get; set; }
         public string ClientInstalledReason { get; set; }
         public DateTime? RefreshComplianceState { get; set; }
+        public string CMClientGUID { get; set; }
     }
 }


### PR DESCRIPTION
Hi,

As discussed on Twitter, here's a Pull Request for some bits of code that add a function to retrieve and store the ConfigMgr Client GUID. It can be useful to have this information stored in logs or in the database to troubleshoot issues with duplicated Client GUID.

It goes in pair with this PR for the Client Health Script : https://github.com/AndersRodland/ConfigMgrClientHealth/pull/52